### PR TITLE
Bugfix/complex

### DIFF
--- a/py/fable/__init__.py
+++ b/py/fable/__init__.py
@@ -8,7 +8,7 @@ __all__ = [
 ]
 
 
-__version__ = '1.0'
+__version__ = '1.0.1'
 __author__ = '''Daan Camps'''
 __maintainer__ = 'Daan Camps'
 __email__ = 'daancamps@gmail.com'

--- a/py/fable/test_fable.py
+++ b/py/fable/test_fable.py
@@ -1,0 +1,31 @@
+from .fable import fable
+from qiskit_aer import AerSimulator
+import numpy as np
+
+
+def test_fable_real():
+    n = 3
+    a = np.random.randn(2**n, 2**n)
+
+    simulator = AerSimulator(method="unitary")
+
+    circ, alpha = fable(a)
+    circ.save_state()
+    u_be = simulator.run(circ).result().get_unitary().data
+    np.testing.assert_array_almost_equal(
+        a/alpha/2**n,  np.real(u_be[:2**n, :2**n])
+    )
+
+
+def test_fable_complex():
+    n = 3
+    a = np.random.randn(2**n, 2**n) + 1j * np.random.randn(2**n, 2**n)
+
+    simulator = AerSimulator(method="unitary")
+
+    circ, alpha = fable(a)
+    circ.save_state()
+    u_be = simulator.run(circ).result().get_unitary().data
+    np.testing.assert_array_almost_equal(
+        a/alpha/2**n,  u_be[:2**n, :2**n]
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fable-circuits
-version = 0.1.1
+version = 1.0.1
 author = Daan Camps
 author_email = daancamps@gmail.com
 description = Fast Approximate Block Encoding Circuits


### PR DESCRIPTION
- Bugfix for complex-valued fable: use `compose` method instead of deprecated `+` operator on `QuantumCircuit` objects
- Added feature: optional epsilon compression value
- Added simple pytest integration tests for real and complex random matrices
- Bumped the version number to 1.0.1.